### PR TITLE
Persist route manager filters and language

### DIFF
--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/i18n.js
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/i18n.js
@@ -3,6 +3,32 @@ import { initReactI18next } from 'react-i18next';
 import enTranslation from './locales/en/translation.json';  // Імпортуємо з відповідної папки
 import ukTranslation from './locales/uk/translation.json';  // Імпортуємо з відповідної папки
 
+const resolveInitialLanguage = () => {
+  if (typeof window === 'undefined') {
+    return 'en';
+  }
+
+  return (
+    localStorage.getItem('i18nextLng') ||
+    localStorage.getItem('language') ||
+    'en'
+  );
+};
+
+const persistLanguageSelection = (language) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.setItem('i18nextLng', language);
+    localStorage.setItem('language', language);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to persist selected language', error);
+  }
+};
+
 i18n
   .use(initReactI18next)
   .init({
@@ -10,11 +36,15 @@ i18n
       en: { translation: enTranslation },
       uk: { translation: ukTranslation },
     },
-    lng: 'en',  // Мова за замовчуванням
+    lng: resolveInitialLanguage(),  // Мова за замовчуванням
     fallbackLng: 'en',  // Якщо вибрана мова недоступна, використовується fallback
     interpolation: {
       escapeValue: false,  // React вже екранує небезпечні символи
     },
   });
+
+i18n.on('languageChanged', persistLanguageSelection);
+
+persistLanguageSelection(i18n.language);
 
 export default i18n;

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/PassengerList.css
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/PassengerList.css
@@ -20,3 +20,119 @@
 .rm-passenger-list li {
   margin-bottom: 5px;
 }
+
+.passenger-requests-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.passenger-requests-controls label {
+  font-weight: 500;
+}
+
+.passenger-requests-controls input[type="text"] {
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid #555;
+  background-color: #2a2a2a;
+  color: #fff;
+}
+
+.passenger-requests-controls input[type="text"]:focus {
+  outline: none;
+  border-color: #4a90e2;
+  box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.35);
+}
+
+.passenger-requests-controls input::placeholder {
+  color: #bdbdbd;
+}
+
+.date-range-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.date-picker-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.9rem;
+}
+
+.date-picker-input {
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid #555;
+  background-color: #2a2a2a;
+  color: #fff;
+}
+
+.date-picker-input:focus {
+  outline: none;
+  border-color: #4a90e2;
+  box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.35);
+}
+
+.passenger-requests-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.passenger-requests-options label,
+.rm-passenger-list .filters label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.rm-passenger-list .filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.rm-passenger-list .filters input[type="radio"],
+.passenger-requests-options input[type="checkbox"] {
+  accent-color: #4a90e2;
+}
+
+.passenger-requests-status {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  color: #e0e0e0;
+}
+
+.passenger-requests-status button {
+  padding: 6px 12px;
+  border-radius: 4px;
+  border: none;
+  background-color: #4a90e2;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.passenger-requests-status button:hover:not(:disabled) {
+  background-color: #357ab8;
+}
+
+.passenger-requests-status button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.passenger-requests-error {
+  margin-top: 4px;
+  color: #ffb4b4;
+  font-size: 0.9rem;
+}

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/PassengerRequestsTable.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/PassengerRequestsTable.jsx
@@ -1,0 +1,423 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
+import dayjs from "dayjs";
+import axios from "../../utils/axiosInstance";
+import { API_ENDPOINTS } from "../../config/apiConfig";
+import { AgGridReact } from "ag-grid-react";
+import "ag-grid-community/styles/ag-grid.css";
+import "ag-grid-community/styles/ag-theme-alpine.css";
+
+import "./PassengerList.css";
+
+const DEFAULT_DIRECTION = "WORK_TO_HOME";
+
+const formatDateForApi = (date) => dayjs(date).format("YYYY-MM-DD HH:mm:ss");
+
+const FILTERS_STORAGE_KEY = "routeManager.passengerRequestsFilters";
+
+const PassengerRequestsTable = () => {
+  const { t } = useTranslation();
+
+  const savedFilters = useMemo(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    try {
+      const storedValue = localStorage.getItem(FILTERS_STORAGE_KEY);
+      return storedValue ? JSON.parse(storedValue) : null;
+    } catch (error) {
+      console.error("Failed to parse saved passenger request filters", error);
+      return null;
+    }
+  }, []);
+
+  const defaultStartDate = useMemo(() => dayjs().add(1, "day").startOf("day"), []);
+
+  const [startDate, setStartDate] = useState(() => {
+    if (savedFilters?.startDate && dayjs(savedFilters.startDate).isValid()) {
+      return dayjs(savedFilters.startDate).toDate();
+    }
+
+    return defaultStartDate.toDate();
+  });
+
+  const [endDate, setEndDate] = useState(() => {
+    if (savedFilters?.endDate && dayjs(savedFilters.endDate).isValid()) {
+      return dayjs(savedFilters.endDate).toDate();
+    }
+
+    return defaultStartDate.add(1, "day").toDate();
+  });
+
+  const [allowExtendedInterval, setAllowExtendedInterval] = useState(
+    savedFilters?.allowExtendedInterval ?? false
+  );
+  const [searchQuery, setSearchQuery] = useState(savedFilters?.searchQuery ?? "");
+  const [directionFilter, setDirectionFilter] = useState(
+    savedFilters?.directionFilter ?? DEFAULT_DIRECTION
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const payload = {
+      startDate: dayjs(startDate).toISOString(),
+      endDate: dayjs(endDate).toISOString(),
+      allowExtendedInterval,
+      searchQuery,
+      directionFilter,
+    };
+
+    try {
+      localStorage.setItem(FILTERS_STORAGE_KEY, JSON.stringify(payload));
+    } catch (error) {
+      console.error("Failed to persist passenger request filters", error);
+    }
+  }, [allowExtendedInterval, directionFilter, endDate, searchQuery, startDate]);
+
+  const [requests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchRequests = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params = {
+        start_date: formatDateForApi(startDate),
+        end_date: formatDateForApi(endDate),
+        search: searchQuery,
+      };
+
+      const response = await axios.get(API_ENDPOINTS.getFilteredTripRequests, {
+        params,
+      });
+
+      if (Array.isArray(response.data)) {
+        setRequests(response.data);
+      } else {
+        console.warn("Unexpected passenger requests payload", response.data);
+        setRequests([]);
+      }
+    } catch (err) {
+      console.error("Error fetching passenger requests:", err);
+      setRequests([]);
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [endDate, searchQuery, startDate]);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      fetchRequests();
+    }, 300);
+
+    return () => clearTimeout(timeoutId);
+  }, [fetchRequests]);
+
+  const handleStartDateChange = (date) => {
+    if (!date) return;
+
+    setStartDate(date);
+
+    if (!allowExtendedInterval) {
+      const adjustedEndDate = dayjs(date).add(1, "day").toDate();
+      setEndDate(adjustedEndDate);
+    }
+  };
+
+  const handleEndDateChange = (date) => {
+    if (!date) return;
+    setEndDate(date);
+  };
+
+  const toggleAllowExtendedInterval = () => {
+    setAllowExtendedInterval((prev) => {
+      const next = !prev;
+      if (!next) {
+        setEndDate(dayjs(startDate).add(1, "day").toDate());
+      }
+      return next;
+    });
+  };
+
+  const filteredRequests = useMemo(() => {
+    if (directionFilter === "ALL") {
+      return requests;
+    }
+
+    return requests.filter((request) => request.direction === directionFilter);
+  }, [directionFilter, requests]);
+
+  const columnDefs = useMemo(
+    () => [
+      { headerName: t("request_id"), field: "id", maxWidth: 100 },
+      {
+        headerName: t("passenger_first_name"),
+        field: "passenger_first_name",
+        minWidth: 140,
+      },
+      {
+        headerName: t("passenger_last_name"),
+        field: "passenger_last_name",
+        minWidth: 140,
+      },
+      {
+        headerName: t("passenger_phone"),
+        field: "passenger_phone",
+        minWidth: 160,
+      },
+      {
+        headerName: t("direction"),
+        field: "direction",
+        minWidth: 140,
+        cellStyle: { fontWeight: "bold" },
+      },
+      {
+        headerName: t("departure_info"),
+        marryChildren: true,
+        children: [
+          {
+            headerName: t("departure_time"),
+            field: "departure_time",
+            minWidth: 170,
+            valueFormatter: (params) =>
+              params.value ? dayjs(params.value).format("DD-MM-YYYY HH:mm") : "",
+          },
+          {
+            headerName: t("pickup_city"),
+            field: "pickup_city",
+            minWidth: 120,
+          },
+          {
+            headerName: t("pickup_street"),
+            field: "pickup_street",
+            minWidth: 160,
+          },
+          {
+            headerName: t("pickup_house"),
+            field: "pickup_house",
+            maxWidth: 120,
+          },
+          {
+            headerName: t("pickup_latitude"),
+            field: "pickup_latitude",
+            maxWidth: 140,
+          },
+          {
+            headerName: t("pickup_longitude"),
+            field: "pickup_longitude",
+            maxWidth: 140,
+          },
+        ],
+      },
+      {
+        headerName: t("arrival_info"),
+        marryChildren: true,
+        children: [
+          {
+            headerName: t("arrival_time"),
+            field: "arrival_time",
+            minWidth: 170,
+            valueFormatter: (params) =>
+              params.value ? dayjs(params.value).format("DD-MM-YYYY HH:mm") : "",
+          },
+          {
+            headerName: t("dropoff_city"),
+            field: "dropoff_city",
+            minWidth: 120,
+          },
+          {
+            headerName: t("dropoff_street"),
+            field: "dropoff_street",
+            minWidth: 160,
+          },
+          {
+            headerName: t("dropoff_house"),
+            field: "dropoff_house",
+            maxWidth: 120,
+          },
+          {
+            headerName: t("dropoff_latitude"),
+            field: "dropoff_latitude",
+            maxWidth: 140,
+          },
+          {
+            headerName: t("dropoff_longitude"),
+            field: "dropoff_longitude",
+            maxWidth: 140,
+          },
+        ],
+      },
+      { headerName: t("passenger_id"), field: "passenger", maxWidth: 110 },
+      {
+        headerName: t("is_active"),
+        field: "is_active",
+        maxWidth: 120,
+        valueFormatter: (params) =>
+          params.value ? t("yes") : t("no"),
+      },
+      {
+        headerName: t("comment"),
+        field: "comment",
+        minWidth: 260,
+        flex: 1,
+      },
+    ],
+    [t]
+  );
+
+  const defaultColDef = useMemo(
+    () => ({
+      resizable: true,
+      sortable: true,
+      filter: true,
+    }),
+    []
+  );
+
+  const overlayNoRowsTemplate = useMemo(
+    () =>
+      `<span class="ag-overlay-loading-center">${t(
+        "no_passenger_requests",
+        "No passenger requests match the current filters."
+      )}</span>`,
+    [t]
+  );
+
+  const overlayLoadingTemplate = useMemo(
+    () =>
+      `<span class="ag-overlay-loading-center">${t(
+        "loading",
+        "Loading..."
+      )}</span>`,
+    [t]
+  );
+
+  return (
+    <div className="rm-passenger-list">
+      <h3>{t("passenger_trip_requests", "Passenger requests")}</h3>
+      <div className="passenger-requests-controls">
+        <label htmlFor="passenger-request-search">{t("search_by_name")}</label>
+        <input
+          id="passenger-request-search"
+          type="text"
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder={t("enter_name_or_last_name")}
+        />
+
+        <div className="date-range-picker">
+          <div className="date-picker-field">
+            <span>{t("start_date")}</span>
+            <DatePicker
+              selected={startDate}
+              onChange={handleStartDateChange}
+              showTimeSelect
+              timeFormat="HH:mm"
+              timeIntervals={15}
+              dateFormat="dd.MM.yyyy HH:mm"
+              className="date-picker-input"
+            />
+          </div>
+          <div className="date-picker-field">
+            <span>{t("end_date")}</span>
+            <DatePicker
+              selected={endDate}
+              onChange={handleEndDateChange}
+              minDate={startDate}
+              showTimeSelect
+              timeFormat="HH:mm"
+              timeIntervals={15}
+              dateFormat="dd.MM.yyyy HH:mm"
+              className="date-picker-input"
+              disabled={!allowExtendedInterval}
+            />
+          </div>
+        </div>
+
+        <div className="passenger-requests-options">
+          <label>
+            <input
+              type="checkbox"
+              checked={allowExtendedInterval}
+              onChange={toggleAllowExtendedInterval}
+            />
+            {t("allow_extended_interval")}
+          </label>
+        </div>
+
+        <div className="filters">
+          <label>
+            <input
+              type="radio"
+              name="directionFilter"
+              checked={directionFilter === "WORK_TO_HOME"}
+              onChange={() => setDirectionFilter("WORK_TO_HOME")}
+            />
+            {t("to_home")}
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="directionFilter"
+              checked={directionFilter === "HOME_TO_WORK"}
+              onChange={() => setDirectionFilter("HOME_TO_WORK")}
+            />
+            {t("to_work")}
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="directionFilter"
+              checked={directionFilter === "ALL"}
+              onChange={() => setDirectionFilter("ALL")}
+            />
+            {t("show_all_requests")}
+          </label>
+        </div>
+
+        <div className="passenger-requests-status">
+          <button type="button" onClick={fetchRequests} disabled={loading}>
+            {t("refresh", "Refresh")}
+          </button>
+          <span>
+            {t("total", "Total")}: {filteredRequests.length}
+          </span>
+          {loading && <span>{t("loading", "Loading...")}</span>}
+        </div>
+        {error && (
+          <div className="passenger-requests-error">
+            {t(
+              "error_loading_requests",
+              "Failed to load passenger requests."
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="ag-theme-alpine" style={{ height: "420px", marginTop: "20px" }}>
+        <AgGridReact
+          rowData={filteredRequests}
+          columnDefs={columnDefs}
+          defaultColDef={defaultColDef}
+          pagination
+          paginationPageSize={10}
+          animateRows
+          overlayNoRowsTemplate={overlayNoRowsTemplate}
+          overlayLoadingTemplate={overlayLoadingTemplate}
+          suppressCellFocus
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PassengerRequestsTable;

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/RouteManagement.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/RouteManagement.jsx
@@ -16,12 +16,11 @@ import dayjs from "dayjs";
 import DriverList from "./DriverList";
 
 import VehicleList from "./VehicleList";
-import PassengerList from "./PassengerList";
+import PassengerRequestsTable from "./PassengerRequestsTable";
 
 const RouteManagement = ({
   drivers = [],
   vehicles = [],
-  passengers = [],
   routes = [],
   copiedRoutes = [],
 }) => {
@@ -68,7 +67,7 @@ const RouteManagement = ({
             >
               {t("grouping_list_to_route")}
             </button>
-            <PassengerList passengers={passengers} />
+            <PassengerRequestsTable />
           </div>
           <div className="rm-middle-column">
             <button

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/TopNavBar.css
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/TopNavBar.css
@@ -45,4 +45,23 @@
     background-color: #3a3a3a;
     color: #fff;
   }
+
+  .language-selector {
+    display: flex;
+    align-items: center;
+    margin-right: 20px;
+    color: #fff;
+  }
+
+  .language-selector label {
+    margin-right: 8px;
+  }
+
+  .language-selector select {
+    padding: 5px;
+    border: 2px solid #C0C0C0;
+    border-radius: 5px;
+    background-color: #3a3a3a;
+    color: #fff;
+  }
   

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/TopNavBar.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/TopNavBar.jsx
@@ -2,22 +2,103 @@ import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import "./TopNavBar.css";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
 import { format } from "date-fns";
 
+const TOP_NAV_STORAGE_KEY = "routeManager.topNavDateFilters";
+
 const TopNavBar = () => {
-  const { t } = useTranslation();
-  const navigate = useNavigate();
+  const { t, i18n } = useTranslation();
+  const [language, setLanguage] = useState(() => {
+    if (typeof window === "undefined") {
+      return i18n.language || "en";
+    }
+
+    const savedLanguage =
+      localStorage.getItem("i18nextLng") ||
+      localStorage.getItem("language") ||
+      i18n.language ||
+      "en";
+    return savedLanguage;
+  });
+
+  const getStoredDateFilters = () => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    try {
+      const storedValue = localStorage.getItem(TOP_NAV_STORAGE_KEY);
+      return storedValue ? JSON.parse(storedValue) : null;
+    } catch (error) {
+      console.error("Failed to parse saved top nav filters", error);
+      return null;
+    }
+  };
+
   const [startDateTime, setStartDateTime] = useState(() => {
+    const storedFilters = getStoredDateFilters();
+    if (storedFilters?.startDateTime) {
+      return storedFilters.startDateTime;
+    }
+
     const now = new Date();
     return format(now, "yyyy-MM-dd'T'HH:mm");
   });
 
   const [endDateTime, setEndDateTime] = useState(() => {
+    const storedFilters = getStoredDateFilters();
+    if (storedFilters?.endDateTime) {
+      return storedFilters.endDateTime;
+    }
+
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
     return format(tomorrow, "yyyy-MM-dd'T'HH:mm");
   });
+
+  useEffect(() => {
+    if (language && i18n.language !== language) {
+      i18n.changeLanguage(language);
+    }
+  }, [i18n, language]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    localStorage.setItem("i18nextLng", language);
+    localStorage.setItem("language", language);
+  }, [language]);
+
+  useEffect(() => {
+    const handleLanguageChanged = (lng) => {
+      setLanguage(lng);
+    };
+
+    i18n.on("languageChanged", handleLanguageChanged);
+
+    return () => {
+      i18n.off("languageChanged", handleLanguageChanged);
+    };
+  }, [i18n]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const payload = {
+      startDateTime,
+      endDateTime,
+    };
+
+    try {
+      localStorage.setItem(TOP_NAV_STORAGE_KEY, JSON.stringify(payload));
+    } catch (error) {
+      console.error("Failed to persist top nav filters", error);
+    }
+  }, [endDateTime, startDateTime]);
 
   const handleStartChange = (e) => {
     setStartDateTime(e.target.value);
@@ -28,6 +109,10 @@ const TopNavBar = () => {
 
   const handleEndChange = (e) => {
     setEndDateTime(e.target.value);
+  };
+
+  const handleLanguageChange = (event) => {
+    setLanguage(event.target.value);
   };
   return (
     <div className="top-nav-bar">
@@ -48,6 +133,17 @@ const TopNavBar = () => {
           value={endDateTime}
           onChange={handleEndChange}
         />
+      </div>
+      <div className="language-selector">
+        <label htmlFor="language-select">{t("language", "Language")}</label>
+        <select
+          id="language-select"
+          value={language}
+          onChange={handleLanguageChange}
+        >
+          <option value="en">EN</option>
+          <option value="uk">UK</option>
+        </select>
       </div>
       <div className="nav-buttons">
         <Link to="/map-of-routes" className="nav-button">


### PR DESCRIPTION
## Summary
- persist passenger request filter values between visits using local storage
- add a language selector to the route manager top bar and remember the selection on reload
- initialize i18n with the stored language and update storage whenever it changes

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a6590298833282c1f10569319309