### PR TITLE
Define reusable date range helpers for route manager filters

### DIFF
--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/PassengerList.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/PassengerList.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -11,21 +11,18 @@ import axios from "../../utils/axiosInstance";
 import { API_ENDPOINTS } from "../../config/apiConfig";
 
 import dayjs from "dayjs";
+import { DAY_IN_MS, getInitialDateRange } from "../../utils/dateRange";
 
 import "./PassengerList.css";
 
 const PassengerList = ({ passengers }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const tomorrow = new Date();
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  tomorrow.setHours(0, 0, 0, 0);
+  const initialDateRange = useMemo(() => getInitialDateRange(), []);
   const userLanguage = localStorage.getItem("i18nextLng") || "en"; // Задайте за замовчуванням "en"
 
-  const [startDate, setStartDate] = useState(tomorrow);
-  const [endDate, setEndDate] = useState(
-    new Date(tomorrow.getTime() + 24 * 60 * 60 * 1000)
-  );
+  const [startDate, setStartDate] = useState(initialDateRange.start);
+  const [endDate, setEndDate] = useState(initialDateRange.end);
   const [passengerData, setPassengerData] = useState([]);
   const [requests, setRequests] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
@@ -124,7 +121,7 @@ useEffect(() => {
   const handleStartDateChange = (date) => {
     setStartDate(date);
     if (!allowExtendedInterval) {
-      setEndDate(new Date(date.getTime() + 24 * 60 * 60 * 1000));
+      setEndDate(new Date(date.getTime() + DAY_IN_MS));
     }
   };
 

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/PassengerRequestsTable.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/PassengerRequestsTable.jsx
@@ -5,6 +5,7 @@ import "react-datepicker/dist/react-datepicker.css";
 import dayjs from "dayjs";
 import axios from "../../utils/axiosInstance";
 import { API_ENDPOINTS } from "../../config/apiConfig";
+import { DAY_IN_MS, getInitialDateRange } from "../../utils/dateRange";
 import { AgGridReact } from "ag-grid-react";
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-alpine.css";
@@ -31,24 +32,21 @@ const PassengerRequestsTable = () => {
     }
   }, []);
 
-  const defaultStartDate = useMemo(
-    () => dayjs().add(1, "day").startOf("day"),
-    []
-  );
+  const initialDateRange = useMemo(() => getInitialDateRange(), []);
 
   // 2) Стани фільтрів (ініціалізуємо з savedFilters, якщо валідні)
   const [startDate, setStartDate] = useState(() => {
     if (savedFilters?.startDate && dayjs(savedFilters.startDate).isValid()) {
       return dayjs(savedFilters.startDate).toDate();
     }
-    return defaultStartDate.toDate();
+    return initialDateRange.start;
   });
 
   const [endDate, setEndDate] = useState(() => {
     if (savedFilters?.endDate && dayjs(savedFilters.endDate).isValid()) {
       return dayjs(savedFilters.endDate).toDate();
     }
-    return defaultStartDate.add(1, "day").toDate();
+    return initialDateRange.end;
   });
 
   const [allowExtendedInterval, setAllowExtendedInterval] = useState(
@@ -127,7 +125,7 @@ const PassengerRequestsTable = () => {
     if (!date) return;
     setStartDate(date);
     if (!allowExtendedInterval) {
-      setEndDate(dayjs(date).add(1, "day").toDate());
+      setEndDate(new Date(date.getTime() + DAY_IN_MS));
     }
   };
 
@@ -139,7 +137,7 @@ const PassengerRequestsTable = () => {
   const toggleAllowExtendedInterval = () =>
     setAllowExtendedInterval((prev) => {
       const next = !prev;
-      if (!next) setEndDate(dayjs(startDate).add(1, "day").toDate());
+      if (!next) setEndDate(new Date(startDate.getTime() + DAY_IN_MS));
       return next;
     });
 

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/RouteManagement.css
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/RouteManagement.css
@@ -26,6 +26,12 @@
   min-width: 0; /* Забезпечує правильне масштабування колонок */
 }
 
+.rm-middle-column {
+  align-self: flex-start;
+  height: auto;
+  overflow: visible;
+}
+
 .rm-route-button {
   width: 100%;
   padding: 10px;

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/utils/dateRange.js
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/utils/dateRange.js
@@ -1,0 +1,23 @@
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Returns a Date representing the start of tomorrow (00:00 local time).
+ */
+export const getTomorrowStart = () => {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(0, 0, 0, 0);
+  return tomorrow;
+};
+
+/**
+ * Returns the default date range used across the route manager screens:
+ * from the beginning of tomorrow until the beginning of the day after.
+ */
+export const getInitialDateRange = () => {
+  const start = getTomorrowStart();
+  const end = new Date(start.getTime() + DAY_IN_MS);
+  return { start, end };
+};
+
+export { DAY_IN_MS };


### PR DESCRIPTION
## Summary
- add a shared date range helper for tomorrow-based filters across the route manager views
- update the passenger requests table to initialise its filters with the shared helper and reuse the shared day-length constant
- initialise the passenger list filters with the helper so both views stay in sync when clamping the end date

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbb8382cb88332bca0887386120880