### PR TITLE
Add ordered passenger list table to route management

### DIFF
--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListsTable.css
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListsTable.css
@@ -1,0 +1,92 @@
+.ordered-passenger-lists {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ordered-passenger-lists__filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  align-items: end;
+}
+
+.ordered-passenger-lists__filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ordered-passenger-lists__filter-group label {
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.ordered-passenger-lists__filter-group input,
+.ordered-passenger-lists__filter-group select {
+  padding: 8px;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+.ordered-passenger-lists__reset {
+  padding: 10px 16px;
+  background-color: #f0f4f8;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.ordered-passenger-lists__reset:hover {
+  background-color: #dfe8f3;
+}
+
+.ordered-passenger-lists__table-wrapper {
+  background: #ffffff;
+  border: 1px solid #e0e6ed;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.ordered-passenger-lists__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.ordered-passenger-lists__table thead {
+  background-color: #f7f9fc;
+}
+
+.ordered-passenger-lists__table th,
+.ordered-passenger-lists__table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #e5e9f0;
+  text-align: left;
+  color: #1f2933;
+}
+
+.ordered-passenger-lists__table tbody tr:nth-child(even) {
+  background-color: #fbfdff;
+}
+
+.ordered-passenger-lists__empty {
+  text-align: center;
+  padding: 20px 0;
+  color: #6b7280;
+}
+
+.ordered-passenger-lists__status {
+  padding: 16px;
+  text-align: center;
+  font-weight: 600;
+  color: #4a5568;
+}
+
+.ordered-passenger-lists__status--error {
+  color: #c53030;
+  background-color: #fff5f5;
+}

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListsTable.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListsTable.jsx
@@ -1,0 +1,327 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import dayjs from "dayjs";
+
+import axios from "../../utils/axiosInstance";
+import { API_ENDPOINTS } from "../../config/apiConfig";
+
+import "./OrderedPassengerListsTable.css";
+
+const FILTER_STORAGE_KEY = "orderedPassengerListsFilters";
+
+const formatForDateTimeInput = (value) =>
+  value ? dayjs(value).format("YYYY-MM-DDTHH:mm") : "";
+
+const createDefaultFilters = () => {
+  const startOfTomorrow = dayjs().add(1, "day").startOf("day");
+  const endOfTomorrow = startOfTomorrow.endOf("day");
+
+  return {
+    direction: "",
+    is_active: "",
+    start_city: "",
+    search_query: "",
+    start_date: formatForDateTimeInput(startOfTomorrow),
+    end_date: formatForDateTimeInput(endOfTomorrow),
+  };
+};
+
+const readStoredFilters = () => {
+  if (typeof window === "undefined") {
+    return createDefaultFilters();
+  }
+
+  try {
+    const storedValue = sessionStorage.getItem(FILTER_STORAGE_KEY);
+    if (!storedValue) {
+      return createDefaultFilters();
+    }
+
+    const parsedValue = JSON.parse(storedValue);
+    return {
+      ...createDefaultFilters(),
+      ...parsedValue,
+    };
+  } catch (error) {
+    console.error("Failed to read ordered passenger list filters from sessionStorage", error);
+    return createDefaultFilters();
+  }
+};
+
+const formatForRequest = (value) =>
+  value && dayjs(value).isValid()
+    ? dayjs(value).format("YYYY-MM-DD HH:mm:ss")
+    : null;
+
+const OrderedPassengerListsTable = () => {
+  const { t } = useTranslation();
+
+  const [filters, setFilters] = useState(() => readStoredFilters());
+  const [orderedLists, setOrderedLists] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const filterRequestParams = useMemo(() => {
+    const parsedIsActive =
+      filters.is_active === ""
+        ? null
+        : filters.is_active === "true";
+
+    return {
+      estimated_start_time__gte: formatForRequest(filters.start_date),
+      estimated_end_time__lte: formatForRequest(filters.end_date),
+      direction: filters.direction || null,
+      is_active: parsedIsActive,
+      start_city__icontains: filters.start_city || null,
+      search: filters.search_query || null,
+    };
+  }, [filters]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      sessionStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify(filters));
+    }
+  }, [filters]);
+
+  useEffect(() => {
+    const fetchOrderedPassengerLists = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await axios.get(
+          API_ENDPOINTS.getOrderedPassengerLists,
+          {
+            params: filterRequestParams,
+          }
+        );
+
+        const data = Array.isArray(response.data) ? response.data : [];
+        setOrderedLists(data);
+      } catch (err) {
+        console.error("Failed to load ordered passenger lists", err);
+        setError(err);
+        setOrderedLists([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchOrderedPassengerLists();
+  }, [filterRequestParams]);
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target;
+
+    setFilters((prev) => {
+      const next = {
+        ...prev,
+        [name]: value,
+      };
+
+      if (name === "start_date" && value && prev.end_date) {
+        const nextStart = dayjs(value);
+        if (nextStart.isValid() && nextStart.isAfter(dayjs(prev.end_date))) {
+          next.end_date = value;
+        }
+      }
+
+      if (name === "end_date" && value && prev.start_date) {
+        const nextEnd = dayjs(value);
+        if (nextEnd.isValid() && nextEnd.isBefore(dayjs(prev.start_date))) {
+          next.start_date = value;
+        }
+      }
+
+      return next;
+    });
+  };
+
+  const handleResetFilters = () => {
+    setFilters(createDefaultFilters());
+  };
+
+  return (
+    <div className="ordered-passenger-lists">
+      <div className="ordered-passenger-lists__filters">
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="direction">
+            {t("direction", { defaultValue: "Direction" })}
+          </label>
+          <select
+            id="direction"
+            name="direction"
+            value={filters.direction}
+            onChange={handleInputChange}
+          >
+            <option value="">
+              {t("all", { defaultValue: "All" })}
+            </option>
+            <option value="HOME_TO_WORK">
+              {t("home_to_work", { defaultValue: "Home to Work" })}
+            </option>
+            <option value="WORK_TO_HOME">
+              {t("work_to_home", { defaultValue: "Work to Home" })}
+            </option>
+          </select>
+        </div>
+
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="is_active">
+            {t("status", { defaultValue: "Status" })}
+          </label>
+          <select
+            id="is_active"
+            name="is_active"
+            value={filters.is_active}
+            onChange={handleInputChange}
+          >
+            <option value="">
+              {t("all", { defaultValue: "All" })}
+            </option>
+            <option value="true">
+              {t("active", { defaultValue: "Active" })}
+            </option>
+            <option value="false">
+              {t("inactive", { defaultValue: "Inactive" })}
+            </option>
+          </select>
+        </div>
+
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="start_city">
+            {t("start_city", { defaultValue: "Start city" })}
+          </label>
+          <input
+            id="start_city"
+            type="text"
+            name="start_city"
+            value={filters.start_city}
+            onChange={handleInputChange}
+            placeholder={t("enter_city", { defaultValue: "Enter city" })}
+          />
+        </div>
+
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="search_query">
+            {t("search", { defaultValue: "Search" })}
+          </label>
+          <input
+            id="search_query"
+            type="text"
+            name="search_query"
+            value={filters.search_query}
+            onChange={handleInputChange}
+            placeholder={t("search_passengers", { defaultValue: "Search passengers" })}
+          />
+        </div>
+
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="start_date">
+            {t("start_date", { defaultValue: "Start date" })}
+          </label>
+          <input
+            id="start_date"
+            type="datetime-local"
+            name="start_date"
+            value={filters.start_date}
+            onChange={handleInputChange}
+          />
+        </div>
+
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="end_date">
+            {t("end_date", { defaultValue: "End date" })}
+          </label>
+          <input
+            id="end_date"
+            type="datetime-local"
+            name="end_date"
+            value={filters.end_date}
+            onChange={handleInputChange}
+          />
+        </div>
+
+        <button
+          type="button"
+          className="ordered-passenger-lists__reset"
+          onClick={handleResetFilters}
+        >
+          {t("reset_filters", { defaultValue: "Reset filters" })}
+        </button>
+      </div>
+
+      <div className="ordered-passenger-lists__table-wrapper">
+        {loading && (
+          <div className="ordered-passenger-lists__status">
+            {t("loading", { defaultValue: "Loading" })}...
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="ordered-passenger-lists__status ordered-passenger-lists__status--error">
+            {t("error_loading_passenger_lists", {
+              defaultValue: "Failed to load ordered passenger lists",
+            })}
+          </div>
+        )}
+
+        {!loading && !error && (
+          <table className="ordered-passenger-lists__table">
+            <thead>
+              <tr>
+                <th>{t("ID", { defaultValue: "ID" })}</th>
+                <th>{t("direction", { defaultValue: "Direction" })}</th>
+                <th>{t("estimated_start_time", { defaultValue: "Start time" })}</th>
+                <th>{t("estimated_end_time", { defaultValue: "End time" })}</th>
+                <th>{t("start_city", { defaultValue: "Start city" })}</th>
+                <th>{t("end_city", { defaultValue: "End city" })}</th>
+                <th>{t("start_passenger_last_name", { defaultValue: "Start passenger" })}</th>
+                <th>{t("end_passenger_last_name", { defaultValue: "End passenger" })}</th>
+                <th>{t("status", { defaultValue: "Status" })}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orderedLists.length === 0 ? (
+                <tr>
+                  <td colSpan={9} className="ordered-passenger-lists__empty">
+                    {t("no_data", { defaultValue: "No data available" })}
+                  </td>
+                </tr>
+              ) : (
+                orderedLists.map((list) => (
+                  <tr key={list.id}>
+                    <td>{list.id}</td>
+                    <td>{list.direction}</td>
+                    <td>
+                      {list.estimated_start_time
+                        ? dayjs(list.estimated_start_time).format("YYYY-MM-DD HH:mm")
+                        : "-"}
+                    </td>
+                    <td>
+                      {list.estimated_end_time
+                        ? dayjs(list.estimated_end_time).format("YYYY-MM-DD HH:mm")
+                        : "-"}
+                    </td>
+                    <td>{list.start_city || "-"}</td>
+                    <td>{list.end_city || "-"}</td>
+                    <td>{list.start_passenger_last_name || "-"}</td>
+                    <td>{list.end_passenger_last_name || "-"}</td>
+                    <td>
+                      {typeof list.is_active === "boolean"
+                        ? list.is_active
+                          ? t("active", { defaultValue: "Active" })
+                          : t("inactive", { defaultValue: "Inactive" })
+                        : "-"}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default OrderedPassengerListsTable;

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/RouteManagement.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/RouteManagement.jsx
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import DriverList from "./DriverList";
 import VehicleList from "./VehicleList";
 import PassengerRequestsTable from "./PassengerRequestsTable";
-import PassengerList from "./PassengerList";
+import OrderedPassengerListsTable from "./OrderedPassengerListsTable";
 
 const RouteManagement = ({
   drivers = [],
@@ -67,9 +67,9 @@ const RouteManagement = ({
               {t("ordered_passenger_list")}
             </button>
           </div>
-          
-            <PassengerList  />
-          
+
+          <OrderedPassengerListsTable />
+
         </div>
 
         <div className="rm-center-column">


### PR DESCRIPTION
## Summary
- replace the placeholder passenger list in route management with the ordered passenger lists table
- add an ordered passenger list table component that loads data from the API and keeps filters in session storage
- introduce styling for the ordered passenger list filters and table layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc1cb35198833292d37fac6efa9355