### PR TITLE
Add route map column to ordered passenger list details

### DIFF
--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/App.js
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/App.js
@@ -49,6 +49,7 @@ import "react-toastify/dist/ReactToastify.css";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import OrderedPassengerList from "./pages/RoutManager/OrderedPassengerListView/OrderedPassengerList";
+import OrderedPassengerListDetails from "./pages/RoutManager/OrderedPassengerListView/OrderedPassengerListDetails";
 
 function App() {
   return (
@@ -131,6 +132,10 @@ function App() {
           <Route
             path="/ordered-passenger-list/ordered-passenger-list"
             element={<OrderedPassengerList />}
+          />
+          <Route
+            path="/ordered-passenger-lists/:listId"
+            element={<OrderedPassengerListDetails />}
           />
           <Route path="/route-map" element={<RouteMapModal />} />
          

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListDetails.css
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListDetails.css
@@ -1,0 +1,133 @@
+.ordered-passenger-list-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  color: #fff;
+  background-color: #1f2937;
+  min-height: 100vh;
+  box-sizing: border-box;
+}
+
+.ordered-passenger-list-details__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.ordered-passenger-list-details__header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.ordered-passenger-list-details__back {
+  background-color: #2563eb;
+  border: none;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.ordered-passenger-list-details__back:hover {
+  background-color: #1d4ed8;
+}
+
+.ordered-passenger-list-details__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.ordered-passenger-list-details__label {
+  font-weight: 600;
+  margin-right: 0.5rem;
+}
+
+.ordered-passenger-list-details__status {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  background: rgba(37, 99, 235, 0.15);
+  color: #bfdbfe;
+}
+
+.ordered-passenger-list-details__status--error {
+  background: rgba(220, 38, 38, 0.15);
+  color: #fecaca;
+}
+
+.ordered-passenger-list-details__content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.65fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  flex: 1;
+}
+
+.ordered-passenger-list-details__section {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 0;
+}
+
+.ordered-passenger-list-details__section-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.ordered-passenger-list-details__grid-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 360px;
+}
+
+.ordered-passenger-list-details__map-wrapper {
+  flex: 1;
+}
+
+.ordered-passenger-list-details__grid {
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+}
+
+.ordered-passenger-list-details__grid .ag-root-wrapper {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.ordered-passenger-list-details__grid .ag-header-cell-label {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.ordered-passenger-list-details__grid .ag-cell {
+  color: #111827;
+}
+
+.ordered-passenger-list-details__empty {
+  color: #94a3b8;
+  font-size: 1rem;
+}
+
+@media (max-width: 1280px) {
+  .ordered-passenger-list-details__content {
+    grid-template-columns: 1fr;
+  }
+
+  .ordered-passenger-list-details__map-wrapper,
+  .ordered-passenger-list-details__grid-wrapper {
+    min-height: 280px;
+  }
+}

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListDetails.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListDetails.jsx
@@ -1,0 +1,281 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import dayjs from "dayjs";
+
+import axios from "../../../utils/axiosInstance";
+import { API_ENDPOINTS } from "../../../config/apiConfig";
+
+import { AgGridReact } from "ag-grid-react";
+import "ag-grid-community/styles/ag-grid.css";
+import "ag-grid-community/styles/ag-theme-alpine.css";
+
+import "./OrderedPassengerListDetails.css";
+import OrderedPassengerListRouteMap from "./OrderedPassengerListRouteMap";
+
+const formatDateTime = (value) =>
+  value && dayjs(value).isValid() ? dayjs(value).format("YYYY-MM-DD HH:mm") : "-";
+
+const OrderedPassengerListDetails = () => {
+  const { listId } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  const initialList = location.state?.orderedList || null;
+
+  const [listDetails, setListDetails] = useState(initialList);
+  const [passengers, setPassengers] = useState(
+    Array.isArray(initialList?.trip_requests) ? initialList.trip_requests : []
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const defaultColDef = useMemo(
+    () => ({
+      sortable: true,
+      filter: true,
+      resizable: true,
+      minWidth: 120,
+      flex: 1,
+    }),
+    []
+  );
+
+  const passengerColumnDefs = useMemo(
+    () => [
+      {
+        headerName: t("sequence_number", { defaultValue: "Sequence" }),
+        field: "sequence_number",
+        maxWidth: 140,
+        filter: "agNumberColumnFilter",
+      },
+      {
+        headerName: t("request_id", { defaultValue: "Request ID" }),
+        field: "id",
+        maxWidth: 140,
+        filter: "agNumberColumnFilter",
+      },
+      {
+        headerName: t("passenger_first_name", { defaultValue: "First name" }),
+        field: "passenger_first_name",
+      },
+      {
+        headerName: t("passenger_last_name", { defaultValue: "Last name" }),
+        field: "passenger_last_name",
+      },
+      {
+        headerName: t("direction", { defaultValue: "Direction" }),
+        field: "direction",
+      },
+      {
+        headerName: t("departure_time", { defaultValue: "Departure" }),
+        field: "departure_time",
+        valueFormatter: ({ value }) => formatDateTime(value),
+        filter: false,
+        minWidth: 180,
+      },
+      {
+        headerName: t("arrival_time", { defaultValue: "Arrival" }),
+        field: "arrival_time",
+        valueFormatter: ({ value }) => formatDateTime(value),
+        filter: false,
+        minWidth: 180,
+      },
+      {
+        headerName: t("pickup_city", { defaultValue: "Pickup city" }),
+        field: "pickup_city",
+      },
+      {
+        headerName: t("pickup_street", { defaultValue: "Pickup street" }),
+        field: "pickup_street",
+      },
+      {
+        headerName: t("pickup_house", { defaultValue: "Pickup house" }),
+        field: "pickup_house",
+        maxWidth: 140,
+      },
+      {
+        headerName: t("dropoff_city", { defaultValue: "Dropoff city" }),
+        field: "dropoff_city",
+      },
+      {
+        headerName: t("dropoff_street", { defaultValue: "Dropoff street" }),
+        field: "dropoff_street",
+      },
+      {
+        headerName: t("dropoff_house", { defaultValue: "Dropoff house" }),
+        field: "dropoff_house",
+        maxWidth: 140,
+      },
+      {
+        headerName: t("passenger_phone", { defaultValue: "Passenger phone" }),
+        field: "passenger_phone",
+        minWidth: 180,
+      },
+      {
+        headerName: t("comment", { defaultValue: "Comment" }),
+        field: "comment",
+        minWidth: 240,
+        flex: 2,
+      },
+    ],
+    [t]
+  );
+
+  useEffect(() => {
+    if (!listId) {
+      return;
+    }
+
+    const fetchListDetails = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await axios.get(
+          API_ENDPOINTS.getOrderedPassengerListDetails(listId)
+        );
+
+        const details = response.data;
+        setListDetails(details);
+        setPassengers(Array.isArray(details?.trip_requests) ? details.trip_requests : []);
+      } catch (err) {
+        console.error("Failed to load ordered passenger list details", err);
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchListDetails();
+  }, [listId]);
+
+  const listSummary = useMemo(() => {
+    if (!listDetails) {
+      return null;
+    }
+
+    return {
+      id: listDetails.id,
+      direction: listDetails.direction,
+      startTime: formatDateTime(listDetails.estimated_start_time),
+      endTime: formatDateTime(listDetails.estimated_end_time),
+      startCity: listDetails.start_city,
+      endCity: listDetails.end_city,
+      isActive: listDetails.is_active,
+    };
+  }, [listDetails]);
+
+  return (
+    <div className="ordered-passenger-list-details">
+      <div className="ordered-passenger-list-details__header">
+        <button
+          type="button"
+          className="ordered-passenger-list-details__back"
+          onClick={() => navigate(-1)}
+        >
+          {t("back", { defaultValue: "Back" })}
+        </button>
+        <h1>{t("ordered_passenger_list_details", { defaultValue: "Ordered passenger list" })}</h1>
+      </div>
+
+      {listSummary && (
+        <div className="ordered-passenger-list-details__summary">
+          <div>
+            <span className="ordered-passenger-list-details__label">
+              {t("ID", { defaultValue: "ID" })}:
+            </span>
+            <span>{listSummary.id ?? "-"}</span>
+          </div>
+          <div>
+            <span className="ordered-passenger-list-details__label">
+              {t("direction", { defaultValue: "Direction" })}:
+            </span>
+            <span>{listSummary.direction || "-"}</span>
+          </div>
+          <div>
+            <span className="ordered-passenger-list-details__label">
+              {t("estimated_start_time", { defaultValue: "Start" })}:
+            </span>
+            <span>{listSummary.startTime}</span>
+          </div>
+          <div>
+            <span className="ordered-passenger-list-details__label">
+              {t("estimated_end_time", { defaultValue: "End" })}:
+            </span>
+            <span>{listSummary.endTime}</span>
+          </div>
+          <div>
+            <span className="ordered-passenger-list-details__label">
+              {t("start_city", { defaultValue: "Start city" })}:
+            </span>
+            <span>{listSummary.startCity || "-"}</span>
+          </div>
+          <div>
+            <span className="ordered-passenger-list-details__label">
+              {t("end_city", { defaultValue: "End city" })}:
+            </span>
+            <span>{listSummary.endCity || "-"}</span>
+          </div>
+          <div>
+            <span className="ordered-passenger-list-details__label">
+              {t("status", { defaultValue: "Status" })}:
+            </span>
+            <span>
+              {listSummary.isActive === true
+                ? t("active", { defaultValue: "Active" })
+                : listSummary.isActive === false
+                ? t("inactive", { defaultValue: "Inactive" })
+                : "-"}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {loading && (
+        <div className="ordered-passenger-list-details__status">
+          {t("loading", { defaultValue: "Loading" })}...
+        </div>
+      )}
+
+      {error && !loading && (
+        <div className="ordered-passenger-list-details__status ordered-passenger-list-details__status--error">
+          {t("error_loading_passenger_list", {
+            defaultValue: "Failed to load ordered passenger list",
+          })}
+        </div>
+      )}
+
+      <div className="ordered-passenger-list-details__content">
+        <div className="ordered-passenger-list-details__section ordered-passenger-list-details__table-section">
+          <h2 className="ordered-passenger-list-details__section-title">
+            {t("passenger_list", { defaultValue: "Passenger list" })}
+          </h2>
+          <div className="ordered-passenger-list-details__grid-wrapper">
+            <div className="ag-theme-alpine ordered-passenger-list-details__grid">
+              <AgGridReact
+                rowData={passengers}
+                columnDefs={passengerColumnDefs}
+                defaultColDef={defaultColDef}
+                suppressCellFocus
+                overlayNoRowsTemplate={`<span class="ordered-passenger-list-details__empty">${t("no_data", { defaultValue: "No data available" })}</span>`}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="ordered-passenger-list-details__section ordered-passenger-list-details__map-section">
+          <h2 className="ordered-passenger-list-details__section-title">
+            {t("route_map", { defaultValue: "Route map" })}
+          </h2>
+          <div className="ordered-passenger-list-details__map-wrapper">
+            <OrderedPassengerListRouteMap tripRequests={passengers} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OrderedPassengerListDetails;

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListRouteMap.css
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListRouteMap.css
@@ -1,0 +1,44 @@
+.ordered-passenger-list-route-map__status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 320px;
+  padding: 1rem;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.65);
+  color: #e2e8f0;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.ordered-passenger-list-route-map__status--error {
+  background: rgba(220, 38, 38, 0.2);
+  color: #fecaca;
+}
+
+.ordered-passenger-list-details__map-section .ordered-passenger-list-route-map__status {
+  min-height: 100%;
+}
+
+.ordered-passenger-list-details__map-wrapper {
+  position: relative;
+  flex: 1;
+  min-height: 360px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.ordered-passenger-list-details__map-wrapper > div {
+  height: 100%;
+}
+
+@media (max-width: 1024px) {
+  .ordered-passenger-list-route-map__status {
+    min-height: 240px;
+  }
+
+  .ordered-passenger-list-details__map-wrapper {
+    min-height: 280px;
+  }
+}

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListRouteMap.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListRouteMap.jsx
@@ -1,0 +1,353 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import { GoogleMap, Marker, Polyline, useJsApiLoader } from "@react-google-maps/api";
+import { useTranslation } from "react-i18next";
+
+import axios from "../../../utils/axiosInstance";
+import { API_ENDPOINTS } from "../../../config/apiConfig";
+
+import "./OrderedPassengerListRouteMap.css";
+
+const MAP_LIBRARIES = ["places"];
+const MAP_CONTAINER_STYLE = { width: "100%", height: "100%" };
+const DEFAULT_CENTER = { lat: 49.8397, lng: 24.0297 };
+
+const parseCoordinate = (value) => {
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const buildLatLng = (lat, lng) => {
+  const parsedLat = parseCoordinate(lat);
+  const parsedLng = parseCoordinate(lng);
+
+  if (parsedLat === null || parsedLng === null) {
+    return null;
+  }
+
+  return { lat: parsedLat, lng: parsedLng };
+};
+
+const OrderedPassengerListRouteMapContent = ({ apiKey, tripRequests }) => {
+  const { t } = useTranslation();
+  const { isLoaded, loadError } = useJsApiLoader({
+    id: "ordered-passenger-list-route-map",
+    googleMapsApiKey: apiKey,
+    libraries: MAP_LIBRARIES,
+  });
+
+  const sortedRequests = useMemo(() => {
+    if (!Array.isArray(tripRequests)) {
+      return [];
+    }
+
+    return [...tripRequests].sort((a, b) => {
+      const first = Number.isFinite(a?.sequence_number) ? a.sequence_number : Number.MAX_SAFE_INTEGER;
+      const second = Number.isFinite(b?.sequence_number) ? b.sequence_number : Number.MAX_SAFE_INTEGER;
+
+      return first - second;
+    });
+  }, [tripRequests]);
+
+  const markers = useMemo(() => {
+    if (!sortedRequests.length) {
+      return [];
+    }
+
+    const canUseSymbols =
+      isLoaded && typeof window !== "undefined" && window.google?.maps?.SymbolPath?.CIRCLE;
+
+    return sortedRequests.flatMap((request, index) => {
+      const displayIndex = Number.isFinite(request?.sequence_number)
+        ? request.sequence_number
+        : index + 1;
+
+      const pickup = buildLatLng(request?.pickup_latitude, request?.pickup_longitude);
+      const dropoff = buildLatLng(request?.dropoff_latitude, request?.dropoff_longitude);
+
+      const markersForRequest = [];
+
+      if (pickup) {
+        markersForRequest.push({
+          key: `pickup-${request?.id ?? displayIndex}`,
+          position: pickup,
+          label: `P${displayIndex}`,
+          icon: canUseSymbols
+            ? {
+                path: window.google.maps.SymbolPath.CIRCLE,
+                scale: 8,
+                fillColor: "#10b981",
+                fillOpacity: 1,
+                strokeColor: "#064e3b",
+                strokeWeight: 1,
+              }
+            : undefined,
+        });
+      }
+
+      if (dropoff) {
+        markersForRequest.push({
+          key: `dropoff-${request?.id ?? displayIndex}`,
+          position: dropoff,
+          label: `D${displayIndex}`,
+          icon: canUseSymbols
+            ? {
+                path: window.google.maps.SymbolPath.CIRCLE,
+                scale: 8,
+                fillColor: "#f97316",
+                fillOpacity: 1,
+                strokeColor: "#7c2d12",
+                strokeWeight: 1,
+              }
+            : undefined,
+        });
+      }
+
+      return markersForRequest;
+    });
+  }, [isLoaded, sortedRequests]);
+
+  const path = useMemo(() => {
+    if (!sortedRequests.length) {
+      return [];
+    }
+
+    const points = [];
+
+    sortedRequests.forEach((request) => {
+      const pickup = buildLatLng(request?.pickup_latitude, request?.pickup_longitude);
+      const dropoff = buildLatLng(request?.dropoff_latitude, request?.dropoff_longitude);
+
+      if (pickup) {
+        points.push(pickup);
+      }
+
+      if (dropoff) {
+        points.push(dropoff);
+      }
+    });
+
+    return points;
+  }, [sortedRequests]);
+
+  const center = useMemo(() => {
+    if (path.length) {
+      const { latSum, lngSum } = path.reduce(
+        (acc, point) => ({ latSum: acc.latSum + point.lat, lngSum: acc.lngSum + point.lng }),
+        { latSum: 0, lngSum: 0 }
+      );
+
+      return {
+        lat: latSum / path.length,
+        lng: lngSum / path.length,
+      };
+    }
+
+    if (markers.length) {
+      const { latSum, lngSum } = markers.reduce(
+        (acc, marker) => ({
+          latSum: acc.latSum + marker.position.lat,
+          lngSum: acc.lngSum + marker.position.lng,
+        }),
+        { latSum: 0, lngSum: 0 }
+      );
+
+      return {
+        lat: latSum / markers.length,
+        lng: lngSum / markers.length,
+      };
+    }
+
+    return DEFAULT_CENTER;
+  }, [markers, path]);
+
+  const handleMapLoad = useCallback(
+    (mapInstance) => {
+      if (!mapInstance || !window.google) {
+        return;
+      }
+
+      if (markers.length === 0) {
+        mapInstance.setCenter(center);
+        mapInstance.setZoom(11);
+        return;
+      }
+
+      const bounds = new window.google.maps.LatLngBounds();
+      markers.forEach((marker) => bounds.extend(marker.position));
+      mapInstance.fitBounds(bounds, 32);
+    },
+    [center, markers]
+  );
+
+  if (loadError) {
+    return (
+      <div className="ordered-passenger-list-route-map__status ordered-passenger-list-route-map__status--error">
+        {t("map_load_error", { defaultValue: "Unable to load map" })}
+      </div>
+    );
+  }
+
+  if (!isLoaded) {
+    return (
+      <div className="ordered-passenger-list-route-map__status">
+        {t("loading", { defaultValue: "Loading" })}...
+      </div>
+    );
+  }
+
+  if (!markers.length) {
+    return (
+      <div className="ordered-passenger-list-route-map__status">
+        {t("no_route_data", { defaultValue: "No route data available" })}
+      </div>
+    );
+  }
+
+  return (
+    <GoogleMap
+      mapContainerStyle={MAP_CONTAINER_STYLE}
+      center={center}
+      options={{
+        mapTypeControl: false,
+        streetViewControl: false,
+        fullscreenControl: false,
+        zoomControl: true,
+        styles: [
+          {
+            elementType: "geometry",
+            stylers: [{ color: "#1f2937" }],
+          },
+          {
+            elementType: "labels.text.stroke",
+            stylers: [{ color: "#1f2937" }],
+          },
+          {
+            elementType: "labels.text.fill",
+            stylers: [{ color: "#f9fafb" }],
+          },
+          {
+            featureType: "administrative",
+            elementType: "geometry",
+            stylers: [{ color: "#4b5563" }],
+          },
+          {
+            featureType: "poi",
+            elementType: "labels.text.fill",
+            stylers: [{ color: "#d1d5db" }],
+          },
+          {
+            featureType: "road",
+            elementType: "geometry",
+            stylers: [{ color: "#374151" }],
+          },
+          {
+            featureType: "road",
+            elementType: "labels.text.fill",
+            stylers: [{ color: "#f3f4f6" }],
+          },
+          {
+            featureType: "road.highway",
+            elementType: "geometry",
+            stylers: [{ color: "#2563eb" }],
+          },
+          {
+            featureType: "water",
+            elementType: "geometry",
+            stylers: [{ color: "#111827" }],
+          },
+        ],
+      }}
+      onLoad={handleMapLoad}
+    >
+      {markers.map((marker) => (
+        <Marker key={marker.key} position={marker.position} label={marker.label} icon={marker.icon} />
+      ))}
+      {path.length > 1 && (
+        <Polyline
+          path={path}
+          options={{
+            strokeColor: "#2563eb",
+            strokeOpacity: 0.85,
+            strokeWeight: 4,
+          }}
+        />
+      )}
+    </GoogleMap>
+  );
+};
+
+OrderedPassengerListRouteMapContent.propTypes = {
+  apiKey: PropTypes.string.isRequired,
+  tripRequests: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+const OrderedPassengerListRouteMap = ({ tripRequests }) => {
+  const { t } = useTranslation();
+  const [apiKey, setApiKey] = useState("");
+  const [loadingKey, setLoadingKey] = useState(false);
+  const [keyError, setKeyError] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchKey = async () => {
+      setLoadingKey(true);
+      setKeyError(null);
+
+      try {
+        const response = await axios.get(API_ENDPOINTS.googleMapsKey);
+        if (!isMounted) {
+          return;
+        }
+
+        setApiKey(response.data?.google_maps_api_key || "");
+      } catch (err) {
+        if (!isMounted) {
+          return;
+        }
+
+        console.error("Failed to load Google Maps key", err);
+        setKeyError(err);
+      } finally {
+        if (isMounted) {
+          setLoadingKey(false);
+        }
+      }
+    };
+
+    fetchKey();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  if (loadingKey) {
+    return (
+      <div className="ordered-passenger-list-route-map__status">
+        {t("loading", { defaultValue: "Loading" })}...
+      </div>
+    );
+  }
+
+  if (keyError || !apiKey) {
+    return (
+      <div className="ordered-passenger-list-route-map__status ordered-passenger-list-route-map__status--error">
+        {t("map_key_error", { defaultValue: "Google Maps key is unavailable" })}
+      </div>
+    );
+  }
+
+  return <OrderedPassengerListRouteMapContent apiKey={apiKey} tripRequests={tripRequests} />;
+};
+
+OrderedPassengerListRouteMap.propTypes = {
+  tripRequests: PropTypes.arrayOf(PropTypes.object),
+};
+
+OrderedPassengerListRouteMap.defaultProps = {
+  tripRequests: [],
+};
+
+export default OrderedPassengerListRouteMap;

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListsTable.css
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListsTable.css
@@ -1,0 +1,102 @@
+.ordered-passenger-lists {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ordered-passenger-lists__filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  align-items: end;
+}
+
+.ordered-passenger-lists__filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ordered-passenger-lists__filter-group label {
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.ordered-passenger-lists__filter-group input,
+.ordered-passenger-lists__filter-group select {
+  padding: 8px;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+.ordered-passenger-lists__reset {
+  padding: 10px 16px;
+  background-color: #f0f4f8;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.ordered-passenger-lists__reset:hover {
+  background-color: #dfe8f3;
+}
+
+.ordered-passenger-lists__table-wrapper {
+  background: #ffffff;
+  border: 1px solid #e0e6ed;
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.ordered-passenger-lists__grid {
+  width: 100%;
+  min-height: 420px;
+  height: 100%;
+}
+
+.ordered-passenger-lists__grid.ag-theme-alpine {
+  --ag-foreground-color: #1f2933;
+  --ag-background-color: #ffffff;
+  --ag-header-background-color: #f7f9fc;
+  --ag-odd-row-background-color: #fbfdff;
+  --ag-borders: solid 1px #e5e9f0;
+  font-size: 14px;
+}
+
+.ordered-passenger-lists__select-button {
+  padding: 6px 12px;
+  background-color: #2563eb;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.ordered-passenger-lists__select-button:hover {
+  background-color: #1d4ed8;
+}
+
+.ordered-passenger-lists__empty {
+  text-align: center;
+  padding: 20px 0;
+  color: #6b7280;
+}
+
+.ordered-passenger-lists__status {
+  padding: 16px;
+  text-align: center;
+  font-weight: 600;
+  color: #4a5568;
+}
+
+.ordered-passenger-lists__status--error {
+  color: #c53030;
+  background-color: #fff5f5;
+}

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListsTable.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListsTable.jsx
@@ -1,0 +1,445 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
+import dayjs from "dayjs";
+
+import axios from "../../utils/axiosInstance";
+import { API_ENDPOINTS } from "../../config/apiConfig";
+
+import { AgGridReact } from "ag-grid-react";
+import "ag-grid-community/styles/ag-grid.css";
+import "ag-grid-community/styles/ag-theme-alpine.css";
+
+import "./OrderedPassengerListsTable.css";
+
+const FILTER_STORAGE_KEY = "orderedPassengerListsFilters";
+
+const formatForDateTimeInput = (value) =>
+  value ? dayjs(value).format("YYYY-MM-DDTHH:mm") : "";
+
+const createDefaultFilters = () => {
+  const startOfTomorrow = dayjs().add(1, "day").startOf("day");
+  const endOfTomorrow = startOfTomorrow.endOf("day");
+
+  return {
+    direction: "",
+    is_active: "",
+    start_city: "",
+    search_query: "",
+    start_date: formatForDateTimeInput(startOfTomorrow),
+    end_date: formatForDateTimeInput(endOfTomorrow),
+  };
+};
+
+const readStoredFilters = () => {
+  if (typeof window === "undefined") {
+    return createDefaultFilters();
+  }
+
+  try {
+    const storedValue = sessionStorage.getItem(FILTER_STORAGE_KEY);
+    if (!storedValue) {
+      return createDefaultFilters();
+    }
+
+    const parsedValue = JSON.parse(storedValue);
+    return {
+      ...createDefaultFilters(),
+      ...parsedValue,
+    };
+  } catch (error) {
+    console.error("Failed to read ordered passenger list filters from sessionStorage", error);
+    return createDefaultFilters();
+  }
+};
+
+const formatForRequest = (value) =>
+  value && dayjs(value).isValid()
+    ? dayjs(value).format("YYYY-MM-DD HH:mm:ss")
+    : null;
+
+const OrderedPassengerListsTable = forwardRef(({ onSelectOrderedList }, ref) => {
+  const { t } = useTranslation();
+
+  const [filters, setFilters] = useState(() => readStoredFilters());
+  const [orderedLists, setOrderedLists] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const defaultColDef = useMemo(
+    () => ({
+      flex: 1,
+      minWidth: 120,
+      sortable: true,
+      filter: true,
+      resizable: true,
+    }),
+    []
+  );
+
+  const dateValueFormatter = useMemo(
+    () =>
+      ({ value }) =>
+        value && dayjs(value).isValid()
+          ? dayjs(value).format("YYYY-MM-DD HH:mm")
+          : "-",
+    []
+  );
+
+  const statusValueFormatter = useMemo(
+    () =>
+      ({ value }) => {
+        if (typeof value !== "boolean") {
+          return "-";
+        }
+        return value
+          ? t("active", { defaultValue: "Active" })
+          : t("inactive", { defaultValue: "Inactive" });
+      },
+    [t]
+  );
+
+  const handleSelectOrderedList = useCallback(
+    (list) => {
+      if (typeof onSelectOrderedList === "function") {
+        onSelectOrderedList(list);
+        return;
+      }
+
+      console.log("Ordered passenger list selected", list);
+    },
+    [onSelectOrderedList]
+  );
+
+  const frameworkComponents = useMemo(
+    () => ({
+      selectButtonRenderer: (params) => (
+        <button
+          type="button"
+          className="ordered-passenger-lists__select-button"
+          onClick={() => handleSelectOrderedList(params.data)}
+        >
+          {t("select", { defaultValue: "Select" })}
+        </button>
+      ),
+    }),
+    [handleSelectOrderedList, t]
+  );
+
+  const columnDefs = useMemo(
+    () => [
+      {
+        headerName: t("ID", { defaultValue: "ID" }),
+        field: "id",
+        filter: "agNumberColumnFilter",
+        maxWidth: 120,
+      },
+      {
+        headerName: t("direction", { defaultValue: "Direction" }),
+        field: "direction",
+        filter: "agTextColumnFilter",
+      },
+      {
+        headerName: t("estimated_start_time", { defaultValue: "Start time" }),
+        field: "estimated_start_time",
+        valueFormatter: dateValueFormatter,
+        filter: false,
+        minWidth: 180,
+      },
+      {
+        headerName: t("estimated_end_time", { defaultValue: "End time" }),
+        field: "estimated_end_time",
+        valueFormatter: dateValueFormatter,
+        filter: false,
+        minWidth: 180,
+      },
+      {
+        headerName: t("start_city", { defaultValue: "Start city" }),
+        field: "start_city",
+        valueFormatter: ({ value }) => value || "-",
+      },
+      {
+        headerName: t("end_city", { defaultValue: "End city" }),
+        field: "end_city",
+        valueFormatter: ({ value }) => value || "-",
+      },
+      {
+        headerName: t("start_passenger_last_name", {
+          defaultValue: "Start passenger",
+        }),
+        field: "start_passenger_last_name",
+        valueFormatter: ({ value }) => value || "-",
+      },
+      {
+        headerName: t("end_passenger_last_name", {
+          defaultValue: "End passenger",
+        }),
+        field: "end_passenger_last_name",
+        valueFormatter: ({ value }) => value || "-",
+      },
+      {
+        headerName: t("status", { defaultValue: "Status" }),
+        field: "is_active",
+        valueFormatter: statusValueFormatter,
+        filter: "agSetColumnFilter",
+      },
+      {
+        headerName: t("actions", { defaultValue: "Actions" }),
+        colId: "actions",
+        filter: false,
+        sortable: false,
+        minWidth: 140,
+        maxWidth: 160,
+        cellRenderer: "selectButtonRenderer",
+      },
+    ],
+    [t, dateValueFormatter, statusValueFormatter]
+  );
+
+  const noRowsOverlayTemplate = useMemo(
+    () =>
+      `<span class="ordered-passenger-lists__empty">${t("no_data", {
+        defaultValue: "No data available",
+      })}</span>`,
+    [t]
+  );
+
+  const filterRequestParams = useMemo(() => {
+    const parsedIsActive =
+      filters.is_active === ""
+        ? null
+        : filters.is_active === "true";
+
+    return {
+      estimated_start_time__gte: formatForRequest(filters.start_date),
+      estimated_end_time__lte: formatForRequest(filters.end_date),
+      direction: filters.direction || null,
+      is_active: parsedIsActive,
+      start_city__icontains: filters.start_city || null,
+      search: filters.search_query || null,
+    };
+  }, [filters]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      sessionStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify(filters));
+    }
+  }, [filters]);
+
+  const fetchOrderedPassengerLists = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await axios.get(
+        API_ENDPOINTS.getOrderedPassengerLists,
+        {
+          params: filterRequestParams,
+        }
+      );
+
+      const data = Array.isArray(response.data) ? response.data : [];
+      setOrderedLists(data);
+    } catch (err) {
+      console.error("Failed to load ordered passenger lists", err);
+      setError(err);
+      setOrderedLists([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [filterRequestParams]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      refresh: fetchOrderedPassengerLists,
+    }),
+    [fetchOrderedPassengerLists]
+  );
+
+  useEffect(() => {
+    fetchOrderedPassengerLists();
+  }, [fetchOrderedPassengerLists]);
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target;
+
+    setFilters((prev) => {
+      const next = {
+        ...prev,
+        [name]: value,
+      };
+
+      if (name === "start_date" && value && prev.end_date) {
+        const nextStart = dayjs(value);
+        if (nextStart.isValid() && nextStart.isAfter(dayjs(prev.end_date))) {
+          next.end_date = value;
+        }
+      }
+
+      if (name === "end_date" && value && prev.start_date) {
+        const nextEnd = dayjs(value);
+        if (nextEnd.isValid() && nextEnd.isBefore(dayjs(prev.start_date))) {
+          next.start_date = value;
+        }
+      }
+
+      return next;
+    });
+  };
+
+  const handleResetFilters = () => {
+    setFilters(createDefaultFilters());
+  };
+
+  return (
+    <div className="ordered-passenger-lists">
+      <div className="ordered-passenger-lists__filters">
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="start_date">
+            {t("start_date", { defaultValue: "Start date" })}
+          </label>
+          <input
+            id="start_date"
+            type="datetime-local"
+            name="start_date"
+            value={filters.start_date}
+            onChange={handleInputChange}
+          />
+        </div>
+
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="end_date">
+            {t("end_date", { defaultValue: "End date" })}
+          </label>
+          <input
+            id="end_date"
+            type="datetime-local"
+            name="end_date"
+            value={filters.end_date}
+            onChange={handleInputChange}
+          />
+        </div>
+
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="start_city">
+            {t("start_city", { defaultValue: "Start city" })}
+          </label>
+          <input
+            id="start_city"
+            type="text"
+            name="start_city"
+            value={filters.start_city}
+            onChange={handleInputChange}
+            placeholder={t("enter_city", { defaultValue: "Enter city" })}
+          />
+        </div>
+
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="search_query">
+            {t("search", { defaultValue: "Search" })}
+          </label>
+          <input
+            id="search_query"
+            type="text"
+            name="search_query"
+            value={filters.search_query}
+            onChange={handleInputChange}
+            placeholder={t("search_passengers", { defaultValue: "Search passengers" })}
+          />
+        </div>
+
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="direction">
+            {t("direction", { defaultValue: "Direction" })}
+          </label>
+          <select
+            id="direction"
+            name="direction"
+            value={filters.direction}
+            onChange={handleInputChange}
+          >
+            <option value="">
+              {t("all", { defaultValue: "All" })}
+            </option>
+            <option value="HOME_TO_WORK">
+              {t("home_to_work", { defaultValue: "Home to Work" })}
+            </option>
+            <option value="WORK_TO_HOME">
+              {t("work_to_home", { defaultValue: "Work to Home" })}
+            </option>
+          </select>
+        </div>
+
+        <div className="ordered-passenger-lists__filter-group">
+          <label htmlFor="is_active">
+            {t("status", { defaultValue: "Status" })}
+          </label>
+          <select
+            id="is_active"
+            name="is_active"
+            value={filters.is_active}
+            onChange={handleInputChange}
+          >
+            <option value="">
+              {t("all", { defaultValue: "All" })}
+            </option>
+            <option value="true">
+              {t("active", { defaultValue: "Active" })}
+            </option>
+            <option value="false">
+              {t("inactive", { defaultValue: "Inactive" })}
+            </option>
+          </select>
+        </div>
+
+        <button
+          type="button"
+          className="ordered-passenger-lists__reset"
+          onClick={handleResetFilters}
+        >
+          {t("reset_filters", { defaultValue: "Reset filters" })}
+        </button>
+      </div>
+
+      <div className="ordered-passenger-lists__table-wrapper">
+        {loading && (
+          <div className="ordered-passenger-lists__status">
+            {t("loading", { defaultValue: "Loading" })}...
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="ordered-passenger-lists__status ordered-passenger-lists__status--error">
+            {t("error_loading_passenger_lists", {
+              defaultValue: "Failed to load ordered passenger lists",
+            })}
+          </div>
+        )}
+
+        {!error && (
+          <div className="ag-theme-alpine ordered-passenger-lists__grid">
+            <AgGridReact
+              rowData={orderedLists}
+              columnDefs={columnDefs}
+              defaultColDef={defaultColDef}
+              frameworkComponents={frameworkComponents}
+              animateRows
+              suppressCellFocus
+              overlayNoRowsTemplate={noRowsOverlayTemplate}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});
+
+OrderedPassengerListsTable.displayName = "OrderedPassengerListsTable";
+
+export default OrderedPassengerListsTable;

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/RouteManagement.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/RouteManagement.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import TopNavBar from "./TopNavBar";
 import "./RouteManagement.css";
 
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import DriverList from "./DriverList";
 import VehicleList from "./VehicleList";
 import PassengerRequestsTable from "./PassengerRequestsTable";
-import PassengerList from "./PassengerList";
+import OrderedPassengerListsTable from "./OrderedPassengerListsTable";
 
 const RouteManagement = ({
   drivers = [],
@@ -17,6 +17,7 @@ const RouteManagement = ({
   copiedRoutes = [],
 }) => {
   const [selectedRoutes, setSelectedRoutes] = useState([]);
+  const orderedPassengerListsRef = useRef(null);
   const { t } = useTranslation();
   const navigate = useNavigate();
 
@@ -32,6 +33,16 @@ const RouteManagement = ({
 
   const handleSubmitRoutes = () => {
     console.log("Submitting routes...");
+  };
+
+  const handleOpenOrderedListDetails = (orderedList) => {
+    if (!orderedList?.id) {
+      return;
+    }
+
+    navigate(`/ordered-passenger-lists/${orderedList.id}`, {
+      state: { orderedList },
+    });
   };
 
   return (
@@ -59,17 +70,19 @@ const RouteManagement = ({
               {t("grouping_list_to_route")}
             </button>
             <button
-              onClick={() =>
-                navigate("/ordered-passenger-list/ordered-passenger-list")
-              }
+              type="button"
+              onClick={() => orderedPassengerListsRef.current?.refresh()}
               className="nav-button"
             >
-              {t("ordered_passenger_list")}
+              {t("refresh", { defaultValue: "Refresh" })}
             </button>
           </div>
-          
-            <PassengerList  />
-          
+
+          <OrderedPassengerListsTable
+            ref={orderedPassengerListsRef}
+            onSelectOrderedList={handleOpenOrderedListDetails}
+          />
+
         </div>
 
         <div className="rm-center-column">


### PR DESCRIPTION
## Summary
- split the ordered passenger list details view into table and route map columns
- add a dedicated Google Maps integration that visualises passenger pickups and drop-offs for the selected list
- style the two-column layout and map container to match the route management theme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc1cb35198833292d37fac6efa9355