### PR TITLE
Adjust ordered passenger list layout and add action buttons

### DIFF
--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListDetails.css
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListDetails.css
@@ -90,7 +90,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  min-height: 360px;
+  min-height: 252px;
 }
 
 .ordered-passenger-list-details__map-wrapper {
@@ -100,8 +100,44 @@
 .ordered-passenger-list-details__grid {
   width: 100%;
   height: 100%;
-  min-height: 400px;
+  min-height: 280px;
   color: #1dc530;
+}
+
+.ordered-passenger-list-details__actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.ordered-passenger-list-details__action-button {
+  padding: 0.6rem 1.25rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out,
+    border-color 0.2s ease-in-out;
+}
+
+.ordered-passenger-list-details__action-button--secondary {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.35);
+  color: #f8fafc;
+}
+
+.ordered-passenger-list-details__action-button--secondary:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.ordered-passenger-list-details__action-button--primary {
+  background: #2563eb;
+  color: #fff;
+}
+
+.ordered-passenger-list-details__action-button--primary:hover {
+  background: #1d4ed8;
 }
 
 .ordered-passenger-list-details__grid .ag-root-wrapper {

--- a/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListDetails.jsx
+++ b/Solution files/myproject/frontend files/nextpointlogix-ui/src/pages/RoutManager/OrderedPassengerListView/OrderedPassengerListDetails.jsx
@@ -264,6 +264,26 @@ const OrderedPassengerListDetails = () => {
               />
             </div>
           </div>
+          <div className="ordered-passenger-list-details__actions">
+            <button
+              type="button"
+              className="ordered-passenger-list-details__action-button ordered-passenger-list-details__action-button--secondary"
+            >
+              {t("ordered_passenger_list_disband", { defaultValue: "Розформувати" })}
+            </button>
+            <button
+              type="button"
+              className="ordered-passenger-list-details__action-button ordered-passenger-list-details__action-button--secondary"
+            >
+              {t("ordered_passenger_list_edit", { defaultValue: "Редагувати" })}
+            </button>
+            <button
+              type="button"
+              className="ordered-passenger-list-details__action-button ordered-passenger-list-details__action-button--primary"
+            >
+              {t("ordered_passenger_list_create_route", { defaultValue: "Створити Маршрут" })}
+            </button>
+          </div>
         </div>
 
         <div className="ordered-passenger-list-details__section ordered-passenger-list-details__map-section">


### PR DESCRIPTION
## Summary
- reduce the passenger list grid height to make room for additional actions
- add an actions toolbar under the ordered passenger list table with buttons for disbanding, editing, and creating a route
- style the new action buttons to match the existing view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd982aff808332b97d0e16b0c68c25